### PR TITLE
 #165483521 add get single transaction endpoint

### DIFF
--- a/server/controllers/transactionsController.js
+++ b/server/controllers/transactionsController.js
@@ -1,7 +1,9 @@
 import controllerResponse from '../helpers/controllerResponse';
 import TransactionsModel from '../models/transactionsModel';
+import AccountsModel from '../models/accountsModel';
 
 const transactionsModel = new TransactionsModel();
+const accountsModel = new AccountsModel();
 
 const transactionsController = {
   async credit(req, res) {
@@ -34,6 +36,32 @@ const transactionsController = {
     try {
       const transactions = await transactionsModel.getAll();
       controllerResponse.successResponse(res, 200, transactions);
+    } catch (error) {
+      controllerResponse.errorResponse(res, 500, error);
+    }
+  },
+
+  async getById(req, res) {
+    try {
+      const transaction = await transactionsModel.getById(req.params.transactionId);
+      if (transaction) {
+        // get account number from trx
+        const { accountNumber } = transaction;
+        // find acct in db
+        const account = await accountsModel.getByAccountNumber(accountNumber);
+        // check if acct owner == userid
+        if (account.owner === req.user.id || req.user.type === 'cashier') {
+          controllerResponse.successResponse(res, 200, transaction);
+        } else {
+          controllerResponse.errorResponse(
+            res,
+            403,
+            new Error('unauthorized to access this resource'),
+          );
+        }
+      } else {
+        controllerResponse.errorResponse(res, 404, new Error('transaction not found'));
+      }
     } catch (error) {
       controllerResponse.errorResponse(res, 500, error);
     }

--- a/server/database/sampleData.js
+++ b/server/database/sampleData.js
@@ -61,12 +61,12 @@ export const sampleAccount2 = {
 };
 
 export const sampleTransaction = {
-  id: 1,
+  id: 3,
   createdOn: new Date(),
   type: 'credit',
-  accountNumber: sampleAccount.accountNumber,
+  accountNumber: sampleAccount2.accountNumber,
   cashier: sampleCashier.id,
-  amount: 300000.0,
-  oldBalance: 0.0,
-  newBalance: 300000.0,
+  amount: 30000,
+  oldBalance: 10000,
+  newBalance: 40000,
 };

--- a/server/helpers/controllerResponse.js
+++ b/server/helpers/controllerResponse.js
@@ -24,6 +24,8 @@ const controllerResponse = {
    */
   errorResponse(res, statusCode, error) {
     // eslint-disable-next-line no-console
+    // console.log(error);
+
     let status;
 
     const notFound = error.message.includes('not found');

--- a/server/routes/transactions.js
+++ b/server/routes/transactions.js
@@ -7,6 +7,8 @@ const transactionsRouter = express.Router();
 
 transactionsRouter.route('/').get(transactionsController.getAll);
 
+transactionsRouter.route('/:transactionId').get(auth.verifyAuth, transactionsController.getById);
+
 transactionsRouter
   .route('/:accountNumber/credit')
   .post(


### PR DESCRIPTION
#### What does this PR do?
- Adds an endpoint where a user can get a single transaction
- Add authorization to the GET route that allows access to only account owner and cashier
#### Description of Task to be completed?
Ensure the endpoint below is working as specified:
```
GET  /api/v1/transactions/<transaction_id>
```
- should deny access if token not provided
- should deny access if the current user is not the account owner or cashier
- should allow access if the current user is the account owner or cashier
#### How should this be manually tested?
- The endpoint should be tested with Postman
- On the local machine, run ` npm run test ` to run automated unit tests
#### Any background context you want to provide?
1. This endpoint will enable an account owner to view single transaction history of their account.
2. The endpoint will also grant cashier access in for audit purpose
#### What are the relevant pivotal tracker stories?
[#165483521 ](https://www.pivotaltracker.com/story/show/165483521 )