### PR TITLE
#165483550 add endpoint for getting all accounts

### DIFF
--- a/server/routes/accounts.js
+++ b/server/routes/accounts.js
@@ -13,7 +13,7 @@ accountsRouter
     validator.validateAccountCreate,
     accountsController.create,
   )
-  .get(accountsController.getAll);
+  .get(auth.verifyAuth, auth.verifyStaff, accountsController.getAll);
 
 accountsRouter
   .route('/:accountNumber')

--- a/server/test/accounts.test.js
+++ b/server/test/accounts.test.js
@@ -109,11 +109,38 @@ describe('POST api/v1/accounts', () => {
 });
 
 /* =================================================================================== */
-describe.skip('GET /api/v1/accounts', () => {
-  it('should get all bank accounts from db', (done) => {
+describe('GET /api/v1/accounts', () => {
+  const path = '/api/v1/accounts';
+  it('should return authentication error if no token/invalid', (done) => {
     chai
       .request(server)
-      .get('/api/v1/accounts')
+      .get(path)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body)
+          .property('error')
+          .eql('token not provided');
+        done(err);
+      });
+  });
+  it('should return authorization error if user is not staff', (done) => {
+    chai
+      .request(server)
+      .get(path)
+      .set('x-access-token', clientToken)
+      .end((err, res) => {
+        expect(res).to.have.status(403);
+        expect(res.body)
+          .property('error')
+          .includes('unauthorized');
+        done(err);
+      });
+  });
+  it('should get all accounts if user is staff', (done) => {
+    chai
+      .request(server)
+      .get(path)
+      .set('x-access-token', adminToken)
       .end((err, res) => {
         const accounts = res.body.data;
         expect(res).to.have.status(200);


### PR DESCRIPTION
#### What does this PR do?
- Adds an endpoint where an admin can get all bank accounts in the database
- Add authorization to the GET route that allows access to only staff (admin/cashier)
#### Description of Task to be completed?
Ensure the endpoint below is working as specified:
```
GET  /api/v1/accounts/
```
- should deny access if token not provided
- should deny access if the current user is not staff
- should allow access if the current user is the account owner or cashier
#### How should this be manually tested?
- The endpoint should be tested with Postman
- On the local machine, run ` npm run test ` to run automated unit tests
#### Any background context you want to provide?
This endpoint will enable staff to easily get data of all account in the database.
#### What are the relevant pivotal tracker stories?
[#165483550 ](https://www.pivotaltracker.com/story/show/165483550 )
