### PR TITLE
#165483587 add endpoint for getting a single account

### DIFF
--- a/server/controllers/accountsController.js
+++ b/server/controllers/accountsController.js
@@ -51,6 +51,21 @@ const accountsController = {
   },
 
   /**
+   * Gets all bank accounts
+   * @param {Object} req - Server request
+   * @param {Object} res - custom server response
+   * @returns {null} -
+   */
+  async getByAccountNumber(req, res) {
+    try {
+      const accounts = await accountsModel.getByAccountNumber(req.params.accountNumber);
+      controllerResponse.successResponse(res, 200, accounts);
+    } catch (error) {
+      controllerResponse.errorResponse(res, 500, error);
+    }
+  },
+
+  /**
    * Activate or deactivates a bank account
    * @param {Object} req - Server request
    * @param {Object} res - custom server response

--- a/server/routes/accounts.js
+++ b/server/routes/accounts.js
@@ -17,6 +17,7 @@ accountsRouter
 
 accountsRouter
   .route('/:accountNumber')
+  .get(auth.verifyAuth, auth.verifyStaff, accountsController.getByAccountNumber)
   .patch(
     auth.verifyAuth,
     auth.verifyAdmin,

--- a/server/test/accounts.test.js
+++ b/server/test/accounts.test.js
@@ -2,7 +2,11 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import server from '../server';
 import {
-  sampleAccount, sampleClient, sampleAdmin, sampleCashier,
+  sampleAccount,
+  sampleClient,
+  sampleAdmin,
+  sampleCashier,
+  sampleAccount2,
 } from '../database/sampleData';
 
 const { expect } = chai;
@@ -146,6 +150,50 @@ describe('GET /api/v1/accounts', () => {
         expect(res).to.have.status(200);
         expect(accounts).to.be.an('array');
         expect(accounts[0]).to.have.property('accountNumber');
+        done(err);
+      });
+  });
+});
+
+/* =================================================================================== */
+describe('GET /api/v1/accounts/:accountNumber', () => {
+  const path = `/api/v1/accounts/${sampleAccount2.accountNumber}`;
+  it('should return authentication error if no token/invalid', (done) => {
+    chai
+      .request(server)
+      .get(path)
+      .end((err, res) => {
+        expect(res).to.have.status(401);
+        expect(res.body)
+          .property('error')
+          .eql('token not provided');
+        done(err);
+      });
+  });
+  it('should return authorization error if user is not staff', (done) => {
+    chai
+      .request(server)
+      .get(path)
+      .set('x-access-token', clientToken)
+      .end((err, res) => {
+        expect(res).to.have.status(403);
+        expect(res.body)
+          .property('error')
+          .includes('unauthorized');
+        done(err);
+      });
+  });
+  it('should get all account if user is staff', (done) => {
+    chai
+      .request(server)
+      .get(path)
+      .set('x-access-token', adminToken)
+      .end((err, res) => {
+        const account = res.body.data;
+        expect(res).to.have.status(200);
+        expect(account)
+          .to.have.property('accountNumber')
+          .eql(sampleAccount2.accountNumber);
         done(err);
       });
   });


### PR DESCRIPTION
#### What does this PR do?
- Adds an endpoint where an admin can get a single bank account in the database
- Add authorization to the GET route that allows access to only staff (admin/cashier)
#### Description of Task to be completed?
Ensure the endpoint below is working as specified:
```
GET  /api/v1/accounts/<account_number>
```
- should deny access if token not provided
- should deny access if the current user is not staff
- should allow access if the current user is staff
#### How should this be manually tested?
- The endpoint should be tested with Postman
- On the local machine, run ` npm run test ` to run automated unit tests
#### Any background context you want to provide?
Staff should be able to retrieve information of a bank account via this endpoint.
#### What are the relevant pivotal tracker stories?
[#165483587 ](https://www.pivotaltracker.com/story/show/165483587 )
